### PR TITLE
Feature/safetychecks

### DIFF
--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/Arena/Arena.fProxy.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/Arena/Arena.fProxy.cs
@@ -52,6 +52,32 @@ namespace LinearAlgebra
         }
         #endregion
 
+        /// <summary>
+        /// For debugging checks if a vector is in the persistent list.
+        /// </summary>
+        public unsafe bool DB_isPersistant(in fProxyN v)
+        {
+            for (int i = 0; i < fProxyVectors.Length; i++)
+            {
+                if (fProxyVectors[i].Data.Ptr == v.Data.Ptr) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// For debugging checks if a vector is in the persistent list.
+        /// </summary>
+        public unsafe bool DB_isTemp(in fProxyN v)
+        {
+            for (int i = 0; i < tempfProxyVectors.Length; i++)
+            {
+                if (tempfProxyVectors[i].Data.Ptr == v.Data.Ptr) return true;
+            }
+
+            return false;
+        }
+
         #region MATRIX
         public fProxyMxN fProxyMat(int dim, bool uninit = false)
         {

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/Arena/Arena.fProxy.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/Arena/Arena.fProxy.cs
@@ -123,6 +123,29 @@ namespace LinearAlgebra
             tempfProxyMatrices.Add(in matrix);
             return matrix;
         }
+
+        public unsafe bool DB_isPersistant(in fProxyMxN v)
+        {
+            for (int i = 0; i < fProxyMatrices.Length; i++)
+            {
+                if (fProxyMatrices[i].Data.Ptr == v.Data.Ptr) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// For debugging checks if a vector is in the persistent list.
+        /// </summary>
+        public unsafe bool DB_isTemp(in fProxyMxN v)
+        {
+            for (int i = 0; i < tempfProxyMatrices.Length; i++)
+            {
+                if (tempfProxyMatrices[i].Data.Ptr == v.Data.Ptr) return true;
+            }
+
+            return false;
+        }
         #endregion
 
     }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/OP/OP.Component.fProxy.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/OP/OP.Component.fProxy.cs
@@ -52,7 +52,7 @@ namespace LinearAlgebra
         public static void addInpl<T>(this T place, T from) where T : unmanaged, IUnsafefProxyArray
         {
             unsafe {
-                UnsafeOP.compAdd(from.Data.Ptr, place.Data.Ptr, from.Data.Length);
+                UnsafeOP.compAdd(place.Data.Ptr, from.Data.Ptr, from.Data.Length);
             }
         }
 
@@ -60,7 +60,7 @@ namespace LinearAlgebra
         public static void subInpl<T>(this T place, T fromB) where T : unmanaged, IUnsafefProxyArray
         {
             unsafe {
-                UnsafeOP.compSub(fromB.Data.Ptr, place.Data.Ptr, fromB.Data.Length);
+                UnsafeOP.compSub(place.Data.Ptr, fromB.Data.Ptr, fromB.Data.Length);
             }
         }
 

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/OP/OP.Component.iProxy.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/OP/OP.Component.iProxy.cs
@@ -51,7 +51,7 @@ namespace LinearAlgebra
         public static void addInpl<T>(this T place, T from) where T : unmanaged, IUnsafeiProxyArray
         {
             unsafe {
-                UnsafeOP.compAdd(from.Data.Ptr, place.Data.Ptr, from.Data.Length);
+                UnsafeOP.compAdd(place.Data.Ptr, from.Data.Ptr,  from.Data.Length);
             }
         }
 
@@ -59,7 +59,7 @@ namespace LinearAlgebra
         public static void subInpl<T>(this T place, T fromB) where T : unmanaged, IUnsafeiProxyArray
         {
             unsafe {
-                UnsafeOP.compSub(fromB.Data.Ptr, place.Data.Ptr, fromB.Data.Length);
+                UnsafeOP.compSub(place.Data.Ptr, fromB.Data.Ptr, fromB.Data.Length);
             }
         }
 

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/OP/UnsafeOP.fProxy.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/OP/UnsafeOP.fProxy.cs
@@ -182,7 +182,7 @@ namespace LinearAlgebra
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void compSub([NoAlias] fProxy* from, [NoAlias] fProxy* target, int n)
+        public static void compSub([NoAlias] fProxy* target, [NoAlias] fProxy* from, int n)
         {
             for (int i = 0; i < n; i++)
                 target[i] -= from[i];

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/OP/UnsafeOP.iProxy.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/OP/UnsafeOP.iProxy.cs
@@ -179,7 +179,7 @@ namespace LinearAlgebra
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void compSub([NoAlias] iProxy* from, [NoAlias] iProxy* target, int n)
+        public static void compSub([NoAlias] iProxy* target, [NoAlias] iProxy* from, int n)
         {
             for (int i = 0; i < n; i++)
                 target[i] -= from[i];

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyMxN.Operators.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyMxN.Operators.cs
@@ -123,7 +123,7 @@ namespace LinearAlgebra
 
             fProxyMxN matrix = lhs.TempCopy();
 
-            fProxyOP.addInpl(rhs, matrix);
+            fProxyOP.addInpl(matrix, rhs);
 
             return matrix;
         }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyMxN.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyMxN.cs
@@ -84,7 +84,9 @@ namespace LinearAlgebra
         }
 
         public void Dispose() {
-
+#if LINALG_DEBUG
+            for (int i = 0; i < Length; i++) this[i] = float.NaN;
+#endif
             Data.Dispose();
         }
 

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyMxN.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyMxN.cs
@@ -97,5 +97,54 @@ namespace LinearAlgebra
         void IMatrix<fProxy>.CopyFrom(IMatrix<fProxy> source) {
             throw new NotImplementedException();
         }
+
+        public override string ToString()
+        {
+            // Get the dimensions of the matrix.
+            int rows = M_Rows;
+            int cols = N_Cols;
+
+            // Determine the maximum width needed for each column.
+            int[] colWidths = new int[cols];
+            for (int j = 0; j < cols; j++)
+            {
+                for (int i = 0; i < rows; i++)
+                {
+                    // Format each number with two decimal places.
+                    string cellStr = this[i, j].ToString();
+                    if (cellStr.Length > colWidths[j])
+                    {
+                        colWidths[j] = cellStr.Length;
+                    }
+                }
+            }
+
+            // Use a StringBuilder to accumulate the formatted matrix string.
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            for (int i = 0; i < rows; i++)
+            {
+                sb.Append("[ ");
+                for (int j = 0; j < cols; j++)
+                {
+                    // Format the cell with the determined width.
+                    string cellStr = this[i, j].ToString().PadLeft(colWidths[j]);
+                    sb.Append(cellStr);
+
+                    // Append a separator if not the last column.
+                    if (j < cols - 1)
+                    {
+                        sb.Append("  ");
+                    }
+                }
+                sb.Append(" ]");
+
+                // Add a newline for each row except the last one.
+                if (i < rows - 1)
+                {
+                    sb.AppendLine();
+                }
+            }
+            return sb.ToString();
+        }
     }
 }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyN.Operators.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyN.Operators.cs
@@ -122,7 +122,7 @@ namespace LinearAlgebra
 
             fProxyN vec = a.TempCopy();
 
-            fProxyOP.addInpl(b, vec);
+            fProxyOP.addInpl(vec, b);
 
             return vec;
         }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyN.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyN.cs
@@ -102,7 +102,9 @@ namespace LinearAlgebra
         }
 
         public void Dispose() {
-
+#if LINALG_DEBUG
+            for (int i = 0; i < N; i++) this[i] = float.NaN;
+#endif
             Data.Dispose();
         }
 

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyN.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/fProxy/fProxyN.cs
@@ -108,5 +108,16 @@ namespace LinearAlgebra
             Data.Dispose();
         }
 
+        public override string ToString()
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            for (int i = 0; i < N; i++)
+            {
+                sb.Append(", ");
+                sb.Append(this[i]);
+            }
+
+            return sb.ToString();
+        }
     }
 }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/iProxy/iProxyMxN.Operators.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/iProxy/iProxyMxN.Operators.cs
@@ -176,7 +176,7 @@ namespace LinearAlgebra
 
             iProxyMxN matrix = lhs.TempCopy();
 
-            iProxyOP.addInpl(rhs, matrix);
+            iProxyOP.addInpl(matrix, rhs);
 
             return matrix;
         }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/iProxy/iProxyMxN.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/iProxy/iProxyMxN.cs
@@ -85,5 +85,54 @@ namespace LinearAlgebra
 
             Data.Dispose();
         }
+
+        public override string ToString()
+        {
+            // Get the dimensions of the matrix.
+            int rows = M_Rows;
+            int cols = N_Cols;
+
+            // Determine the maximum width needed for each column.
+            int[] colWidths = new int[cols];
+            for (int j = 0; j < cols; j++)
+            {
+                for (int i = 0; i < rows; i++)
+                {
+                    // Format each number with two decimal places.
+                    string cellStr = this[i, j].ToString();
+                    if (cellStr.Length > colWidths[j])
+                    {
+                        colWidths[j] = cellStr.Length;
+                    }
+                }
+            }
+
+            // Use a StringBuilder to accumulate the formatted matrix string.
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            for (int i = 0; i < rows; i++)
+            {
+                sb.Append("[ ");
+                for (int j = 0; j < cols; j++)
+                {
+                    // Format the cell with the determined width.
+                    string cellStr = this[i, j].ToString().PadLeft(colWidths[j]);
+                    sb.Append(cellStr);
+
+                    // Append a separator if not the last column.
+                    if (j < cols - 1)
+                    {
+                        sb.Append("  ");
+                    }
+                }
+                sb.Append(" ]");
+
+                // Add a newline for each row except the last one.
+                if (i < rows - 1)
+                {
+                    sb.AppendLine();
+                }
+            }
+            return sb.ToString();
+        }
     }
 }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/iProxy/iProxyN.Operators.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/iProxy/iProxyN.Operators.cs
@@ -176,7 +176,7 @@ namespace LinearAlgebra
 
             iProxyN vec = a.TempCopy();
 
-            iProxyOP.addInpl(b, vec);
+            iProxyOP.addInpl(vec, b);
 
             return vec;
         }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSource/iProxy/iProxyN.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSource/iProxy/iProxyN.cs
@@ -108,5 +108,16 @@ namespace LinearAlgebra
             Data.Dispose();
         }
 
+        public override string ToString()
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            for (int i = 0; i < N; i++)
+            {
+                sb.Append(", ");
+                sb.Append(this[i]);
+            }
+
+            return sb.ToString();
+        }
     }
 }

--- a/Assets/LinearAlgebra/CodeGen/TemplateSourceTests/fProxy/DotOperationTests.fProxy.cs
+++ b/Assets/LinearAlgebra/CodeGen/TemplateSourceTests/fProxy/DotOperationTests.fProxy.cs
@@ -91,7 +91,7 @@ public class fProxyDotOperationTests
             arena.Dispose();
         }
 
-        public void MatVecDot()
+        public unsafe void MatVecDot()
         {
             var arena = new Arena(Allocator.Persistent);
 
@@ -101,9 +101,18 @@ public class fProxyDotOperationTests
             fProxyN x = arena.fProxyVec(inVecLen, 1f);
             fProxyMxN A = arena.fProxyRandomMatrix(outVecLen, inVecLen, -0.01f, 0.01f);
 
+            fProxyN xx = x;
+            fProxyMxN AA = A;
+
             fProxyN b = fProxyOP.dot(A, x);
 
             Assert.AreEqual(outVecLen, b.N);
+
+            Assert.IsTrue(arena.AllocationsCount == 2);
+            Assert.IsTrue(arena.TempAllocationsCount == 1);
+            Assert.IsTrue(arena.DB_isTemp(b));
+            Assert.IsTrue(xx.Data.Ptr == x.Data.Ptr);
+            Assert.IsTrue(AA.Data.Ptr == A.Data.Ptr);
 
             arena.Dispose();
         }
@@ -134,7 +143,7 @@ public class fProxyDotOperationTests
             arena.Dispose();
         }
 
-        public void MatMatDot()
+        public unsafe void MatMatDot()
         {
             var arena = new Arena(Allocator.Persistent);
 
@@ -143,7 +152,16 @@ public class fProxyDotOperationTests
             fProxyMxN A = arena.fProxyIdentityMatrix(matLen);
             fProxyMxN B = arena.fProxyIdentityMatrix(matLen);
 
+            fProxyMxN AA = A;
+            fProxyMxN BB = B;
+
             fProxyMxN C = fProxyOP.dot(A, B);
+
+            Assert.IsTrue(arena.AllocationsCount == 2);
+            Assert.IsTrue(arena.TempAllocationsCount == 1);
+            Assert.IsTrue(arena.DB_isTemp(in C));
+            Assert.IsTrue(BB.Data.Ptr == B.Data.Ptr);
+            Assert.IsTrue(AA.Data.Ptr == A.Data.Ptr);
 
             for (int i = 0; i < matLen; i++)
             for (int j = 0; j < matLen; j++)
@@ -180,7 +198,7 @@ public class fProxyDotOperationTests
             arena.Dispose();
         }
 
-        public void MatVecDotNonSquare()
+        public unsafe void MatVecDotNonSquare()
         {
             var arena = new Arena(Allocator.Persistent);
 
@@ -190,9 +208,18 @@ public class fProxyDotOperationTests
             fProxyN x = arena.fProxyVec(inVecLen, 1f);
             fProxyMxN A = arena.fProxyRandomMatrix(outVecLen, inVecLen, -0.01f, 0.01f);
 
+            fProxyN xx = x;
+            fProxyMxN AA = A;
+
             fProxyN b = fProxyOP.dot(A, x);
 
             Assert.AreEqual(outVecLen, b.N);
+
+            Assert.IsTrue(arena.AllocationsCount == 2);
+            Assert.IsTrue(arena.TempAllocationsCount == 1);
+            Assert.IsTrue(arena.DB_isTemp(b));
+            Assert.IsTrue(xx.Data.Ptr == x.Data.Ptr);
+            Assert.IsTrue(AA.Data.Ptr == A.Data.Ptr);
 
             arena.Dispose();
         }


### PR DESCRIPTION
This fixes a problem with:

addInpl
subInpl

Where these functions would allocate a new buffer on the temp list. For example:

a = arena.floatVec(3, 2);  // allocated in persistent storage
b = arena.floatVec(3, 5);  // allocated in persistent storage
a.addInpl(b);   // a's ptr is moved from the persistent storage array to the temp storage array.

IMO the in-place functions should store the results in the original buffer and not move the buffer. The addInpl call should not move a's buffer from persistent to temp.

This PR also adds a lot of checks to the fProxy unit tests to ensure that vectors and matrices that are allocated persistently are not quietly transformed into temporary vectors and matricies by an operation.

I also added a define  LINALG_DEBUG  which if set will set the contents of matricies and vectors to NaN when Disposed. This helps identify problems where a vector or matrix quietly gets converted from persistent to temp and then disposed by "ClearTemp()" and the code continues accessing the released memory.